### PR TITLE
docs: add MLX alternative implementation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,9 @@ LuxTTS is an lightweight zipvoice based text-to-speech model designed for high q
 
 https://github.com/user-attachments/assets/a3b57152-8d97-43ce-bd99-26dc9a145c29
 
+### Alternative Implementations
+- Apple Silicon MLX implementation (community-maintained): [jishnuvenugopal/LuxTTS-mlx](https://github.com/jishnuvenugopal/LuxTTS-mlx)
+- PyPI package: [LuxTTS-mlx](https://pypi.org/project/LuxTTS-mlx/)
 
 ### The main features are
 - Voice cloning: SOTA voice cloning on par with models 10x larger.


### PR DESCRIPTION
## Summary
Add a short README note linking to the Apple Silicon MLX community implementation and its PyPI package.

## Why
Users running on Apple Silicon often look for an MLX-native path. This adds a discoverable pointer without changing core behavior.

## Changes
- Add an Alternative Implementations section near the top of README
- Link to https://github.com/jishnuvenugopal/LuxTTS-mlx
- Link to https://pypi.org/project/LuxTTS-mlx/