### PR TITLE
enable timestamps modeling_utils.py

### DIFF
--- a/zipvoice/modeling_utils.py
+++ b/zipvoice/modeling_utils.py
@@ -47,7 +47,7 @@ class LuxTTSConfig:
 def process_audio(audio, transcriber, tokenizer, feature_extractor, device, target_rms=0.1, duration=4, feat_scale=0.1):
     prompt_wav, sr = librosa.load(audio, sr=24000, duration=duration)
     prompt_wav2, sr = librosa.load(audio, sr=16000, duration=duration)
-    prompt_text = transcriber(prompt_wav2)["text"]
+    prompt_text = transcriber(prompt_wav2, return_timestamps=True)["text"]
     print(prompt_text)
 
     prompt_wav = torch.from_numpy(prompt_wav).unsqueeze(0)


### PR DESCRIPTION
If the reference audio file is longer than 30 seconds, the following error is observed:
```
ValueError: You have passed more than 3000 mel input features (> 30 seconds) which automatically enables long-form generation which requires the model to predict timestamp tokens. Please either pass return_timestamps=True or make sure to pass no more than 3000 mel input features.
```
I don't know if this is the correct way to fix the problem, but it works for me.