### PR TITLE
Add support for ONNX INT8 models in CPU loading functions

### DIFF
--- a/zipvoice/luxvoice.py
+++ b/zipvoice/luxvoice.py
@@ -7,7 +7,7 @@ class LuxTTS:
     LuxTTS class for encoding prompt and generating speech on cpu/cuda/mps.
     """
 
-    def __init__(self, model_path='YatharthS/LuxTTS', device='cuda', threads=4):
+    def __init__(self, model_path='YatharthS/LuxTTS', device='cuda', threads=4, onnx_int8=False):
         if model_path == 'YatharthS/LuxTTS':
             model_path = None
 
@@ -21,7 +21,9 @@ class LuxTTS:
                 device = 'cpu'
 
         if device == 'cpu':
-            model, feature_extractor, vocos, tokenizer, transcriber = load_models_cpu(model_path, threads)
+            model, feature_extractor, vocos, tokenizer, transcriber = load_models_cpu(
+                model_path, threads, onnx_int8=onnx_int8
+            )
             print("Loading model on CPU")
         else:
             model, feature_extractor, vocos, tokenizer, transcriber = load_models_gpu(model_path, device=device)

--- a/zipvoice/modeling_utils.py
+++ b/zipvoice/modeling_utils.py
@@ -124,15 +124,18 @@ def load_models_gpu(model_path=None, device="cuda"):
     params.sampling_rate = model_config["feature"]["sampling_rate"]
     return model, feature_extractor, vocos, tokenizer, transcriber
 
-def load_models_cpu(model_path = None, num_thread=2):
+def load_models_cpu(model_path = None, num_thread=2, onnx_int8=False):
     params = LuxTTSConfig()
     params.seed = 42
 
-    model_path = snapshot_download('YatharthS/LuxTTS')
+    if model_path is None:
+        model_path = snapshot_download('YatharthS/LuxTTS')
 
     token_file = f"{model_path}/tokens.txt"
-    text_encoder_path = f"{model_path}/text_encoder.onnx"
-    fm_decoder_path = f"{model_path}/fm_decoder.onnx"
+    text_encoder_name = "text_encoder_int8.onnx" if onnx_int8 else "text_encoder.onnx"
+    fm_decoder_name = "fm_decoder_int8.onnx" if onnx_int8 else "fm_decoder.onnx"
+    text_encoder_path = f"{model_path}/{text_encoder_name}"
+    fm_decoder_path = f"{model_path}/{fm_decoder_name}"
     model_config  = f"{model_path}/config.json"
 
     transcriber = pipeline("automatic-speech-recognition", model="openai/whisper-tiny", device='cpu')
@@ -153,5 +156,4 @@ def load_models_cpu(model_path = None, num_thread=2):
     feature_extractor = VocosFbank()
 
     params.sampling_rate = model_config["feature"]["sampling_rate"]
-    params.onnx_int8 = True
     return model, feature_extractor, vocos, tokenizer, transcriber


### PR DESCRIPTION
int8 models were being downloaded by luxtts already, but if you pass a parameter to use them for inference, that was ignored and a hardcoded path to the fp32 models was used instead. Used tests to confirm the logic of the change, then I ran a benchmark script (neither included in this PR since you don't have tests in the repo, figured you didn't want them) to actually compare inference times, got the audio, could hear some quality degradation in the int8 output vs fp32 as expected, int8 was only testing 15-25% faster than fp32, which isn't as much faster as I'd hoped, but I didn't try to optimize that and it might just be my old garbage cpu preventing more impressive performance improvement.

I used **copilot** (raptor mini) to produce the changes while asking it to make as few changes as possible to enable int8 cpu support and **gemini cli** (gemini 3.1 flash) to review and test. Here's gemini's breakdown of the changes:

**zipvoice/luxvoice.py**
   * Constructor Update (__init__): Added the onnx_int8=False parameter to the LuxTTS class signature to allow users to opt-in to quantized models.
   * Flag Propagation: Updated the call to load_models_cpu to pass the onnx_int8 argument, ensuring the preference is respected during model initialization.

**zipvoice/modeling_utils.py**
   * Function Signature: Updated load_models_cpu to accept the onnx_int8 boolean flag.
   * Path Logic Improvement: Modified the model_path assignment to use a conditional check (if model_path is None:). This fixes a bug where the function previously overwrote user-supplied paths with a fresh snapshot_download.
   * Dynamic File Selection: Implemented logic to choose between the standard .onnx files and the _int8.onnx variants based on the onnx_int8 flag.
   * Cleanup: Removed a hardcoded params.onnx_int8 = True at the end of the function, replacing it with the dynamic initialization of the OnnxModel using the user-requested precision.